### PR TITLE
Some fixes to GMNotes

### DIFF
--- a/campaigns/path_to_carcosa.json
+++ b/campaigns/path_to_carcosa.json
@@ -7256,7 +7256,7 @@
               },
               "Nickname": "Sebastien Moreau",
               "Description": "Savage Hysteria",
-              "GMNotes": "{\n  \"id\": \"03079\",\n  \"type\": \"Asset\",\n  \"class\": \"Neutral\",\n  \"traits\": \"Bystander.\",\n  \"cycle\": \"Standalone\"\n}",
+              "GMNotes": "{\n  \"id\": \"03068b\",\n  \"type\": \"Enemy\",\n  \"traits\": \"Monster. Possessed. Elite.\",\n  \"victory\": 0,\n  \"cycle\": \"Standalone\"\n}",
               "AltLookAngle": {
                 "x": 0.0,
                 "y": 0.0,

--- a/campaigns/return_to_tcu.json
+++ b/campaigns/return_to_tcu.json
@@ -6569,7 +6569,7 @@
               },
               "Nickname": "Lodge Cellar",
               "Description": "Lodge.",
-              "GMNotes": "{\n  \"id\": \"05209\",\n  \"type\": \"Location\",\n  \"traits\": \"Lodge.\",\n  \"cycle\": \"Standalone\",\n  \"locationFront\": {\n    \"icons\": \"Tee\",\n    \"connections\": \"Circle|Tilde\"\n  },\n  \"locationBack\": {\n    \"icons\": \"Tee\",\n    \"connections\": \"Circle|Tilde\"\n  }\n}",
+              "GMNotes": "{\n  \"id\": \"05208\",\n  \"type\": \"Location\",\n  \"traits\": \"Lodge.\",\n  \"cycle\": \"Standalone\",\n  \"locationFront\": {\n    \"icons\": \"Tee\",\n    \"connections\": \"Circle|Tilde\"\n  },\n  \"locationBack\": {\n    \"icons\": \"Tee\",\n    \"connections\": \"Circle|Tilde\"\n  }\n}",
               "AltLookAngle": {
                 "x": 0.0,
                 "y": 0.0,

--- a/campaigns/return_to_tptc.json
+++ b/campaigns/return_to_tptc.json
@@ -12566,7 +12566,7 @@
               },
               "Nickname": "The Stranger",
               "Description": "Act 2",
-              "GMNotes": "{\n  \"id\": \"03047a\",\n  \"type\": \"Act\",\n  \"cycle\": \"Standalone\"\n}",
+              "GMNotes": "{\n  \"id\": \"03047c\",\n  \"type\": \"Act\",\n  \"cycle\": \"Standalone\"\n}",
               "AltLookAngle": {
                 "x": 0.0,
                 "y": 0.0,
@@ -12688,7 +12688,7 @@
               },
               "Nickname": "The Stranger",
               "Description": "Act 2",
-              "GMNotes": "{\n  \"id\": \"03047c\",\n  \"type\": \"Act\",\n  \"cycle\": \"Standalone\"\n}",
+              "GMNotes": "{\n  \"id\": \"03047a\",\n  \"type\": \"Act\",\n  \"cycle\": \"Standalone\"\n}",
               "AltLookAngle": {
                 "x": 0.0,
                 "y": 0.0,
@@ -27033,7 +27033,7 @@
                       },
                       "Nickname": "Let The Storm Rage",
                       "Description": "Agenda 2a",
-                      "GMNotes": "{\n  \"id\": \"03276b\",\n  \"type\": \"Agenda\",\n  \"doomThreshold\": 6,\n  \"cycle\": \"Standalone\"\n}",
+                      "GMNotes": "{\n  \"id\": \"03276a\",\n  \"type\": \"Agenda\",\n  \"doomThreshold\": 6,\n  \"cycle\": \"Standalone\"\n}",
                       "AltLookAngle": {
                         "x": 0.0,
                         "y": 0.0,


### PR DESCRIPTION
In Path to Carcosa Sebastien Moreau the Enemy had notes of Sebastien Moreau the Asset. In Return to TCU Lodge Cellar had wrong id.
In Return to TPTC The Stranger (twice) and Let The Storm Rage had incorrect ids.